### PR TITLE
Engine.resume returns Promise that resolves BpmnEngineExecutionApi

### DIFF
--- a/types/bpmn-engine.d.ts
+++ b/types/bpmn-engine.d.ts
@@ -307,7 +307,7 @@ declare module "bpmn-engine" {
      * @param options 
      * @param callback 
      */
-    resume(options?: BpmnEngineExecuteOptions, callback?:()=> void): void;
+    resume(options?: BpmnEngineExecuteOptions, callback?:()=> void): Promise<BpmnEngineExecutionApi>;
 
     /**
      * Stop execution. The instance is terminated.


### PR DESCRIPTION
Hello!

💁‍♀️  This PR adjusts the type definitions for `BpmnEngine` to reflect that `resume()` returns `Promise<BpmnEngineExecutionApi>`, not `void`.

There is a [recent issue](https://github.com/paed01/bpmn-engine/issues/106#issuecomment-681599224) where @paed01 explains how to resume a process from previous stored state. In the suggestion (which does work), we're able to get the Execution API from the return of `engine.resume(...)`. 

I'm using `bpmn-engine` in a TypeScript project and the compiler insists that `engine.resume` returns `void` and that I cannot call methods like `getActivityById` on it. I think all that's needed is to adjust the type declaration to be accurate, but I may be wrong here. I'm no TypeScript wizard!